### PR TITLE
upgrade mybatis plus version v3.4.2 -> v3.4.3.1

### DIFF
--- a/loser-spring-boot-mybatis-starter/pom.xml
+++ b/loser-spring-boot-mybatis-starter/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <mybatis-plus-version>3.4.3.1</mybatis-plus-version>
     </properties>
 
     <dependencies>
@@ -29,7 +30,7 @@
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-boot-starter</artifactId>
-            <version>3.4.2</version>
+            <version>${mybatis-plus-version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
I wan't upgrade the mybatis plus version to v3.4.3.1, the following reasons：
In nta-parent project pom.xml that i find the duplicate jars about mybatis-plus，so we just keep one.
In the mybatis-plus that advised we use the lastest version, so i think we can upgrade version in starter and remove another dependency
